### PR TITLE
Optionally specify mount dabtabase location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 .idea
 build
 build*
+*.egg-info

--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ Mounts are read-only. Mounts are "live", meaning new files added to the source d
 the mount point (assuming there's a matching freezetag), and deleted files will automatically disappear. Similarly,
 changes in tags or freezetag files will be reflected automatically.
 
+A custom location or path may be specified for the database via --db-path. The default location is the local user's
+cache dir. For example, on Debian this would be $HOME/.cache/freezetag/freezefs.db. If a custom folder is specified
+the default name of freezefs.db will still be used. If a custom filename is specified, that will be used.
+
 Note: The initial mount may take awhile depending on how large your library is. Mount metadata is cached on disk, so
 subsequent mounts should activate in just a few seconds.
 

--- a/freezetag/__main__.py
+++ b/freezetag/__main__.py
@@ -60,6 +60,9 @@ def parse_args():
                             '\na few seconds.')
     mount.add_argument('--verbose', '-v', action='store_true', help='Verbose mode.')
     mount.add_argument('mount_point', help='Mount destination.')
+    mount.add_argument('--db-path', type=str, default=None,
+                       help='Optional path to store the freezetag database file.'
+                            '\nIf not specified, the default location is used.')
 
     shave = add_subparser('shave', 'Strip metadata from all music files.',
                           '\n\nOnly music files with supported extensions (.mp3, .flac) will be modified,'

--- a/freezetag/__main__.py
+++ b/freezetag/__main__.py
@@ -61,8 +61,11 @@ def parse_args():
     mount.add_argument('--verbose', '-v', action='store_true', help='Verbose mode.')
     mount.add_argument('mount_point', help='Mount destination.')
     mount.add_argument('--db-path', type=str, default=None,
-                       help='Optional path to store the freezetag database file.'
-                            '\nIf not specified, the default location is used.')
+                       help='Optional custom path to store the freezetag database file.'
+                            '\nIf not specified, the default user cache location is used.'
+                            '\nEg: $HOME/.cache/freezetag/freezedb.fs.'
+                            '\nIf a directory is specified, the default name remains.'
+                            '\nOtherwise, a custom directory and filename will be respected.')
 
     shave = add_subparser('shave', 'Strip metadata from all music files.',
                           '\n\nOnly music files with supported extensions (.mp3, .flac) will be modified,'

--- a/freezetag/commands.py
+++ b/freezetag/commands.py
@@ -427,4 +427,4 @@ def show(path, as_json, **kwargs):
 
 def mount(directory, mount_point, verbose, db_path=None, **kwargs):
     from .freezefs import FreezeFS
-    FreezeFS(verbose).mount(directory, mount_point, db_path)
+    FreezeFS(verbose, db_path=db_path).mount(directory, mount_point)

--- a/freezetag/commands.py
+++ b/freezetag/commands.py
@@ -425,7 +425,6 @@ def show(path, as_json, **kwargs):
         for f in frozen.files:
             print(f'{f.checksum.hex()} {f.path}')
 
-
-def mount(directory, mount_point, verbose, **kwargs):
+def mount(directory, mount_point, verbose, db_path=None, **kwargs):
     from .freezefs import FreezeFS
-    FreezeFS(verbose).mount(directory, mount_point)
+    FreezeFS(verbose).mount(directory, mount_point, db_path)

--- a/freezetag/freezefs.py
+++ b/freezetag/freezefs.py
@@ -111,7 +111,9 @@ class FreezeFS(Operations, FileSystemEventHandler):
         else:
             # Use the default path if no db_path is provided
             self.db_path = CACHE_DIR / 'freezefs.db'
-        
+
+        # Ensure the directory for the database exists
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self.checksum_db = ChecksumDB(self.db_path)
 
         # self.freezetag_ref_lock must be acquired before accessing.
@@ -141,8 +143,9 @@ class FreezeFS(Operations, FileSystemEventHandler):
         }
 
     def mount(self, directory, mount_point):
-        db_dir = self.db_file.parent
-        db_dir.mkdir(parents=True, exist_ok=True)
+        db_path = Path(self.db_path)  # Ensure db_path is a Path object
+        db_dir = db_path.parent
+        db_dir.mkdir(parents=True, exist_ok=True)  # Ensure the directory exists
 
         observer = Observer()
         observer.schedule(self, directory, recursive=True)


### PR DESCRIPTION
Allows users to optionally specify a custom path and filename, or only path, to support relocation of the freezefs.db. This could be helpful in cases where the data must be persistent but the mount is being run from within a container, or simply for user convenience avoiding the local home folder account.

Also ignores .egg-info due to local build testing via pip.