### PR TITLE
Better Filesystem Capability Checks (e.g. volname & st_birthtime) #5

### DIFF
--- a/freezetag/freezefs.py
+++ b/freezetag/freezefs.py
@@ -35,8 +35,8 @@ FREEZETAG_KEEPALIVE_TIME = 10
 CACHE_DIR = Path(user_cache_dir('freezetag', 'x1ppy'))
 
 ST_ITEMS = ['st_atime', 'st_ctime', 'st_gid', 'st_mode', 'st_mtime', 'st_nlink', 'st_size', 'st_uid']
-if platform.system() != 'Windows':
-    ST_ITEMS.append('st_birthtime')
+# if platform.system() != 'Windows':
+#    ST_ITEMS.append('st_birthtime')
 
 
 # An LRU cache with mostly standard behavior besides one thing: it asks whether
@@ -123,7 +123,7 @@ class FreezeFS(Operations, FileSystemEventHandler):
             'st_atime': now,
             'st_ctime': now,
             'st_mtime': now,
-            'st_birthtime': now,
+            # 'st_birthtime': now,
             'st_mode': S_IFDIR | 0o755,
             'st_nlink': 2,
             'st_gid': gid,
@@ -144,7 +144,7 @@ class FreezeFS(Operations, FileSystemEventHandler):
         self.checksum_db.flush()
 
         print(f'mounting {mount_point}')
-        FUSE(self, mount_point, nothreads=True, foreground=True, fsname='freezefs', volname=Path(mount_point).name)
+        FUSE(self, mount_point, nothreads=True, foreground=True, fsname='freezefs')
 
     # Helpers
     # =======

--- a/freezetag/freezefs.py
+++ b/freezetag/freezefs.py
@@ -144,7 +144,7 @@ class FreezeFS(Operations, FileSystemEventHandler):
         self.checksum_db.flush()
 
         print(f'mounting {mount_point}')
-        FUSE(self, mount_point, nothreads=True, foreground=True, fsname='freezefs')
+        FUSE(self, mount_point, nothreads=True, foreground=True, fsname='freezefs', debug=True)
 
     # Helpers
     # =======


### PR DESCRIPTION
As per @CoordSpace from https://github.com/x1ppy/freezetag/pull/5

> When running `freezetag mount` on non-Mac filesystems, the current set of file attributes and fuse mount settings cause Runtime Errors with fuse such as `fuse: unknown option "volname=Music-freezetag"` and trigger the persistent process to instantly crash out.
> 
> This patch swaps out checks for OS(es) that don't support these features (e.g. `if platform.system() != 'Windows'`) for checks that see if freezetag is running on the one OS variant that does support them: Darwin. This will allow linux (and maybe windows) users to use `freezetag mount` with filesystems that do not support that same filesystem feature set as MacOS.
> 
> So far this patch has been tested on the latest versions of Ubuntu Server and Debian and it clears the hurdles that prevented the new filesystem from being created, allowing well-behaved FLAC and MP3 files to work as expected.

