### PR TITLE
Fix #6: check path matches, rather than blindly selecting metadata

### DIFF
--- a/freezetag/freezefs.py
+++ b/freezetag/freezefs.py
@@ -380,6 +380,12 @@ class FreezeFS(Operations, FileSystemEventHandler):
         if not frozen_entry:
             raise FuseOSError(ENOENT)
 
+        # This is the path, relative to the freezetag file's root, that we are trying to open.
+        # Knowing this is essential to providing the correct metadata.
+        #
+        # TODO: validate that this is correct on all operating systems.
+        target_path = "/".join(frozen_entry.path.parts[2:])
+
         freezetag_path = None
         metadata = None
         if frozen_entry.metadata_len:
@@ -396,8 +402,11 @@ class FreezeFS(Operations, FileSystemEventHandler):
 
             for f in freezetag.data.frozen.files:
                 if f.checksum == item.checksum:
-                    metadata = f.metadata
-                    break
+                    if f.path == target_path:
+                        self._log_verbose(f'opened {f.path} as {path} (target: {target_path})')
+                        metadata = f.metadata
+                        break
+                    self._log_verbose(f'ignoring {f.path} despite matching checksum (target: {target_path})')
 
         file = FuseFile.from_info(file_entry.path, flags, metadata, file_entry.metadata_info, file_entry.metadata_len,
                                   frozen_entry.metadata_len)


### PR DESCRIPTION
Pulling in fix submitted to upstream master