### PR TITLE
Adds support for passing through UID/GID

### DIFF
--- a/freezetag/__main__.py
+++ b/freezetag/__main__.py
@@ -8,126 +8,171 @@ from . import commands
 
 def parse_args():
     parent = argparse.ArgumentParser(add_help=False)
-    main = argparse.ArgumentParser(parents=[parent],
-                                   epilog='Use "freezetag [command] --help" for more information about a command.',
-                                   description='Saves, strips, and restores file paths and music metadata.',
-                                   formatter_class=argparse.RawTextHelpFormatter)
+    main = argparse.ArgumentParser(
+        parents=[parent],
+        epilog='Use "freezetag [command] --help" for more information about a command.',
+        description='Saves, strips, and restores file paths and music metadata.',
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
     sub = main.add_subparsers(metavar='command', dest='command')
     sub.required = True
 
     def add_subparser(command, help, description=''):
-        return sub.add_parser(command, help=help, description=help + description,
-                              formatter_class=argparse.RawTextHelpFormatter, parents=[parent])
+        return sub.add_parser(
+            command,
+            help=help,
+            description=help + description,
+            formatter_class=argparse.RawTextHelpFormatter,
+            parents=[parent],
+        )
 
-    freeze = add_subparser('freeze',
-                           'Save paths and music metadata to a freezetag file.',
-                           '\n\nMusic files with supported extensions (.mp3, .flac) will have their metadata'
-                           '\nsaved in the .ftag file. All files will have their paths saved in the .ftag'
-                           '\nfile. Metadata and path state can be restored using "freezetag thaw".'
-                           '\n\nThe freezetag file will be saved in `directory`. Unless --backup is used, the'
-                           '\nfreezetag file will be named Fa-b-c.ftag, where:'
-                           '\n  a is a 16-character segment that uniquely identifies the music'
-                           '\n  b is an 8-character segment that uniquely identifies the metadata'
-                           '\n  c is an 8-character segment that uniquely identifies the freezetag'
-                           '\n\nThe "a" and "b" segments do not change between freezes if any paths change or'
-                           '\nif any non-music files are modified. Additionally, the "a" segment doesn\'t'
-                           '\nchange if the music files are retagged.'
-                           '\n\nThis means if two different .ftag files have the same "a" segment, they'
-                           '\nrepresent the same set of raw music. If they have both the same "a" and "b"'
-                           '\nsegments, they represent the same set of raw music AND their metadata.'
-                           )
+    freeze = add_subparser(
+        'freeze',
+        'Save paths and music metadata to a freezetag file.',
+        '\n\nMusic files with supported extensions (.mp3, .flac) will have their metadata'
+        '\nsaved in the .ftag file. All files will have their paths saved in the .ftag'
+        '\nfile. Metadata and path state can be restored using "freezetag thaw".'
+        '\n\nThe freezetag file will be saved in `directory`. Unless --backup is used, the'
+        '\nfreezetag file will be named Fa-b-c.ftag, where:'
+        '\n  a is a 16-character segment that uniquely identifies the music'
+        '\n  b is an 8-character segment that uniquely identifies the metadata'
+        '\n  c is an 8-character segment that uniquely identifies the freezetag'
+        '\n\nThe "a" and "b" segments do not change between freezes if any paths change or'
+        '\nif any non-music files are modified. Additionally, the "a" segment doesn\'t'
+        '\nchange if the music files are retagged.'
+        '\n\nThis means if two different .ftag files have the same "a" segment, they'
+        '\nrepresent the same set of raw music. If they have both the same "a" and "b"'
+        '\nsegments, they represent the same set of raw music AND their metadata.'
+    )
 
-    thaw = add_subparser('thaw', 'Restore paths and music metadata from a freezetag file.',
-                         '\n\nBy default, the files will be renamed and restored in-place inside `directory`.'
-                         '\nNote that `directory` itself will be renamed to the "root" saved in the'
-                         '\nfreezetag file.'
-                         '\n\nIf --to is used, files will instead be copied and restored to a subdirectory'
-                         '\n(named "root" from the freezetag file) under the `to` directory, leaving the'
-                         '\nfiles in the source `directory` untouched.')
+    thaw = add_subparser(
+        'thaw',
+        'Restore paths and music metadata from a freezetag file.',
+        '\n\nBy default, the files will be renamed and restored in-place inside `directory`.'
+        '\nNote that `directory` itself will be renamed to the "root" saved in the'
+        '\nfreezetag file.'
+        '\n\nIf --to is used, files will instead be copied and restored to a subdirectory'
+        '\n(named "root" from the freezetag file) under the `to` directory, leaving the'
+        '\nfiles in the source `directory` untouched.'
+    )
 
-    mount = add_subparser('mount',
-                          help='Recursively mount a directory and its freezetags.')
-    mount.add_argument('directory',
-                       help='Directory to mount.'
-                            '\n\nThis directory will be scanned for freezetags and matching files. Any matches'
-                            '\nwill then be mounted as their original state under `mount_point`.'
-                            '\n\nMounts are read-only. Mounts are "live", meaning new files added to the source'
-                            '\ndirectory will automatically appear under the mount point (assuming there\'s a'
-                            '\nmatching freezetag), and deleted files will automatically disappear. Similarly,'
-                            '\nchanges in tags or freezetag files will be reflected automatically.'
-                            '\n\nNote: The initial mount may take awhile depending on how large your library is.'
-                            '\nMount metadata is cached on disk, so subsequent mounts should activate in just'
-                            '\na few seconds.')
-    mount.add_argument('--verbose', '-v', action='store_true', help='Verbose mode.')
-    mount.add_argument('mount_point', help='Mount destination.')
-    mount.add_argument('--db-path', type=str, default=None,
-                       help='Custom path to store the freezetag database file. If not specified it defaults'
-                            '\nto $HOME/.cache/freezetag/freezedb.fs or equivalent user cache location.'
-                            '\nWhen specifying only a custom directory, the db will still be named freezedb.fs.')
+    mount = add_subparser(
+        'mount',
+        'Recursively mount a directory and its freezetags.',
+        '\n\nThis command mounts a virtual filesystem that represents the original state of'
+        '\nyour files as recorded in the freezetag files. It allows you to access the files'
+        '\nwith their original metadata and paths without modifying the original files.'
+    )
 
-    shave = add_subparser('shave', 'Strip metadata from all music files.',
-                          '\n\nOnly music files with supported extensions (.mp3, .flac) will be modified,'
-                          '\nand only supported metadata (Vorbis comments, ID3) will be stripped.')
+    shave = add_subparser(
+        'shave',
+        'Strip metadata from all music files.',
+        '\n\nOnly music files with supported extensions (.mp3, .flac) will be modified,'
+        '\nand only supported metadata (Vorbis comments, ID3) will be stripped.'
+    )
 
-    show = add_subparser('show', 'Display the contents of a freezetag file.')
+    show = add_subparser(
+        'show',
+        'Display the contents of a freezetag file.',
+    )
 
     for parser in [freeze, thaw, shave]:
-        parser.add_argument('directory', nargs='?', default=Path.cwd(),
-                            help='Directory to process (default: current directory).')
+        parser.add_argument(
+            'directory',
+            nargs='?',
+            default=Path.cwd(),
+            help='Directory to process (default: current directory).',
+        )
 
-    show.add_argument('path', nargs='?', metavar='path', default=Path.cwd(),
-                      help='Directory containing .ftag file, or the .ftag file itself\n'
-                           '(default: current directory)')
+    mount.add_argument(
+        'directory',
+        help='Directory to scan for files and freezetags.',
+    )
+    mount.add_argument('mount_point', help='Mount destination.')
+    mount.add_argument(
+        '--verbose', '-v', action='store_true', help='Verbose mode.'
+    )
+    mount.add_argument(
+        '--db-path',
+        type=str,
+        default=None,
+        help=(
+            'Custom path to store the freezetag database file. If not specified it defaults\n'
+            'to $HOME/.cache/freezetag/freezefs.db or equivalent user cache location.\n'
+            'When specifying only a custom directory, the db will still be named freezefs.db.'
+        ),
+    )
+    mount.add_argument(
+        '--uid',
+        type=int,
+        default=None,
+        help='Set the UID for the mounted filesystem. Default is the current user UID.',
+    )
+    mount.add_argument(
+        '--gid',
+        type=int,
+        default=None,
+        help='Set the GID for the mounted filesystem. Default is the current user GID.',
+    )
+    mount.add_argument(
+        '--allow-other',
+        action='store_true',
+        help='Allow other users to access the mounted filesystem.',
+    )
+
+    show.add_argument(
+        'path',
+        nargs='?',
+        metavar='path',
+        default=Path.cwd(),
+        help='Directory containing .ftag file, or the .ftag file itself\n(default: current directory)',
+    )
     show.add_argument('--json', action='store_true', dest='as_json', help='Prints JSON output.')
 
-    thaw.add_argument('--ftag', metavar='path',
-                      help='Path to Freezetag file to use.'
-                           '\n\nIf path is a directory, the .ftag in this directory will be'
-                           '\nused. Otherwise, path must be an .ftag file that will be used'
-                           '\nto thaw.'
-                           '\n\nIf --ftag is not specified, the .ftag in `directory` will be'
-                           '\nused.')
-    thaw.add_argument('--to', metavar='directory',
-                      help='Directory to which thawed files will be copied and restored.'
-                           '\nIf omitted, files will be renamed and restored in-place.')
-    thaw.add_argument('--skip-checks', action='store_true',
-                      help='Skips safety checks.'
-                           '\n\nBy default, thaw verifies that (1) all music files in the'
-                           '\nfreezetag are in `directory`, and (2) `directory` doesn\'t'
-                           '\ncontain unrecognized files when the common music path doesn\'t'
-                           '\nmatch `directory`. The user will be prompted if either of'
-                           '\nthese conditions is not met.'
-                           '\n\nThese checks help prevent unintentional file/directory changes'
-                           '\nif thaw is called with the wrong `directory`; however, the'
-                           '\nthaw will take longer and requires user interaction for prompts.'
-                           '\nPass --skip-checks to disable these checks.')
+    thaw.add_argument(
+        '--ftag',
+        metavar='path',
+        help=(
+            'Path to Freezetag file to use.\n\nIf path is a directory, the .ftag in this directory will be\n'
+            'used. Otherwise, path must be an .ftag file that will be used\nto thaw.\n\nIf --ftag is not specified, the .ftag in `directory` will be\nused.'
+        ),
+    )
+    thaw.add_argument(
+        '--to',
+        metavar='directory',
+        help=(
+            'Directory to which thawed files will be copied and restored.\nIf omitted, files will be renamed and restored in-place.'
+        ),
+    )
+    thaw.add_argument(
+        '--skip-checks',
+        action='store_true',
+        help=(
+            'Skips safety checks.\n\nBy default, thaw verifies that (1) all music files in the\nfreezetag are in `directory`, and (2) `directory` doesn\'t\ncontain unrecognized files when the common music path doesn\'t\nmatch `directory`. The user will be prompted if either of\nthese conditions is not met.\n\nThese checks help prevent unintentional file/directory changes\nif thaw is called with the wrong `directory`; however, the\nthaw will take longer and requires user interaction for prompts.\nPass --skip-checks to disable these checks.'
+        ),
+    )
 
-    freeze.add_argument('--backup', action='store_true',
-                        help='Freeze in incremental backup mode.'
-                             '\n\nThis mode is optimized for repeated incremental backups of the'
-                             '\nsame directory.'
-                             '\n\nIn backup mode, the freezetag file will be saved as'
-                             '\nFyyyy-MM-dd_hh-mm-ss.ftag. File sizes and last modified times'
-                             '\nwill be written to the freezetag file. On subsequent incremental'
-                             '\nbackups, the last created freezetag in this directory will be'
-                             '\nread. Any files whose names haven\'t changed will not have their'
-                             '\nhashes recalculated, making the freeze operation significantly'
-                             '\nfaster.')
-    freeze.add_argument('--ftag', metavar='path',
-                        help='Path to output freezetag file.'
-                             '\n\nIf path is a directory, the freezetag file will be written to'
-                             '\nthis directory, following the naming specifications outlined'
-                             '\nabove. Otherwise, the freezetag file will be named and saved'
-                             '\naccording to the given path.'
-                             '\n\nIf --ftag is not specified, the freezetag file will be written'
-                             '\nto `directory`.')
+    freeze.add_argument(
+        '--backup',
+        action='store_true',
+        help=(
+            'Freeze in incremental backup mode.\n\nThis mode is optimized for repeated incremental backups of the\nsame directory.\n\nIn backup mode, the freezetag file will be saved as\nFyyyy-MM-dd_hh-mm-ss.ftag. File sizes and last modified times\nwill be written to the freezetag file. On subsequent incremental\nbackups, the last created freezetag in this directory will be\nread. Any files whose names haven\'t changed will not have their\nhashes recalculated, making the freeze operation significantly\nfaster.'
+        ),
+    )
+    freeze.add_argument(
+        '--ftag',
+        metavar='path',
+        help=(
+            'Path to output freezetag file.\n\nIf path is a directory, the freezetag file will be written to\nthis directory, following the naming specifications outlined\nabove. Otherwise, the freezetag file will be named and saved\naccording to the given path.\n\nIf --ftag is not specified, the freezetag file will be written\nto `directory`.'
+        ),
+    )
 
     return main.parse_args()
 
 
 def main():
+    args = parse_args()
     try:
-        args = parse_args()
         getattr(commands, args.command)(**vars(args))
     except commands.CommandException as e:
         print(e, file=sys.stderr)

--- a/freezetag/__main__.py
+++ b/freezetag/__main__.py
@@ -114,11 +114,6 @@ def parse_args():
         default=None,
         help='Set the GID for the mounted filesystem. Default is the current user GID.',
     )
-    mount.add_argument(
-        '--allow-other',
-        action='store_true',
-        help='Allow other users to access the mounted filesystem.',
-    )
 
     show.add_argument(
         'path',

--- a/freezetag/commands.py
+++ b/freezetag/commands.py
@@ -421,8 +421,9 @@ def show(path, as_json, **kwargs):
             print(f'{f.checksum.hex()} {f.path}')
 
 
-def mount(directory, mount_point, verbose, db_path=None, uid=None, gid=None, allow_other=False, **kwargs):
+def mount(directory, mount_point, verbose, db_path=None, uid=None, gid=None, **kwargs):
     from .freezefs import FreezeFS
     fs = FreezeFS(verbose, db_path=db_path, uid=uid, gid=gid)
-    fs.mount(directory, mount_point, allow_other=allow_other)
+    fs.mount(directory, mount_point)
+
 

--- a/freezetag/commands.py
+++ b/freezetag/commands.py
@@ -423,5 +423,6 @@ def show(path, as_json, **kwargs):
 
 def mount(directory, mount_point, verbose, db_path=None, uid=None, gid=None, allow_other=False, **kwargs):
     from .freezefs import FreezeFS
-    fs = FreezeFS(verbose, db_path=db_path)
-    fs.mount(directory, mount_point, uid=uid, gid=gid, allow_other=allow_other)
+    fs = FreezeFS(verbose, db_path=db_path, uid=uid, gid=gid)
+    fs.mount(directory, mount_point, allow_other=allow_other)
+

--- a/freezetag/freezefs.py
+++ b/freezetag/freezefs.py
@@ -20,14 +20,14 @@ from .core import ChecksumDB, Freezetag
 
 try:
     from fuse import FUSE, FuseOSError, Operations
-except:
+except ImportError:
     fuse_urls = {
-        'Darwin': 'Install it via homebrew by running "brew cask install osxfuse", or manually from https://github.com/osxfuse/osxfuse/releases/latest.',
-        'Linux': 'Install fuse2 from your package manager, or manually from https://github.com/libfuse/libfuse/releases/tag/fuse-2.9.9.',
+        'Darwin': 'Install it via homebrew by running "brew install macfuse", or manually from https://osxfuse.github.io/',
+        'Linux': 'Install fuse2 from your package manager, or manually from https://github.com/libfuse/libfuse/releases/latest.',
         'Windows': 'Download and install it from https://github.com/billziss-gh/winfsp/releases/latest.',
     }
     print('Could not load FUSE.', file=sys.stderr)
-    print(fuse_urls[platform.system()], file=sys.stderr)
+    print(fuse_urls.get(platform.system(), 'Please install FUSE for your operating system.'), file=sys.stderr)
     sys.exit(1)
 
 FREEZETAG_CACHE_LIMIT = 10
@@ -39,12 +39,7 @@ if platform.system() == 'Darwin':
     ST_ITEMS.append('st_birthtime')
 
 
-# An LRU cache with mostly standard behavior besides one thing: it asks whether
-# an item can be purged before doing so. This prevents the cache from purging
-# freezetags that are still be in use by open files; that way, they won't be
-# needlessly recreated in memory if another file with the same freezetag is
-# opened. This also means the cache could technically expand past its maxsize
-# if all items cannot be purged.
+# An LRU cache with polite eviction
 class PoliteLRUCache(OrderedDict):
     def __init__(self, getter, can_purge, maxsize=128, *args, **kwds):
         self.maxsize = maxsize
@@ -62,7 +57,7 @@ class PoliteLRUCache(OrderedDict):
     def __setitem__(self, key, value):
         super().__setitem__(key, value)
         if len(self) > self.maxsize:
-            for i in range(len(self) - 1):
+            for _ in range(len(self) - self.maxsize):
                 oldest = next(iter(self))
                 if self.can_purge(oldest):
                     del self[oldest]
@@ -89,6 +84,7 @@ class FrozenItem:
         self.checksum = checksum
         self.freezetags = []
         self.files = []
+
 
 class FreezeFS(Operations, FileSystemEventHandler):
     def __init__(self, verbose=False, db_path=None):
@@ -129,8 +125,8 @@ class FreezeFS(Operations, FileSystemEventHandler):
         try:
             gid = os.getgid()
             uid = os.getuid()
-        except:
-            # Windows.
+        except AttributeError:
+            # Windows does not have os.getuid()
             gid = 0
             uid = 0
 
@@ -149,7 +145,12 @@ class FreezeFS(Operations, FileSystemEventHandler):
 
         self.dir_stat = dir_stat_items
 
-    def mount(self, directory, mount_point):
+    def mount(self, directory, mount_point, uid=None, gid=None, allow_other=False):
+        if uid is None:
+            uid = os.getuid()
+        if gid is None:
+            gid = os.getgid()
+
         db_path = Path(self.db_path)  # Ensure db_path is a Path object
         db_dir = db_path.parent
         db_dir.mkdir(parents=True, exist_ok=True)  # Ensure the directory exists
@@ -166,16 +167,27 @@ class FreezeFS(Operations, FileSystemEventHandler):
                 self._add_file(path)
         self.checksum_db.flush()
 
-        print(f'mounting {mount_point}')
+        print(f'Mounting {mount_point}')
 
-        fuse_args = {'nothreads': True, 'foreground': True, 'fsname': 'freezefs', 
-                    'volname': Path(mount_point).name}
+        mount_opts = [f'uid={uid}', f'gid={gid}']
 
-        # Only MacOS supports FUSE volume names, so remove it for other FS to prevent RuntimeError
+        # Include 'allow_other' if needed
+        if allow_other:
+            mount_opts.append('allow_other')
+
+        fuse_args = {
+            'nothreads': True,
+            'foreground': True,
+            'fsname': 'freezefs',
+            'volname': Path(mount_point).name,
+            'options': ','.join(mount_opts),
+        }
+
+        # Only macOS supports FUSE volume names; remove it for other OSes
         if platform.system() != 'Darwin':
-            del fuse_args['volname']
-    
-        self._log_verbose(f'mounting FUSE with these args: {fuse_args}')
+            fuse_args.pop('volname', None)
+
+        self._log_verbose(f'Mounting FUSE with these args: {fuse_args}')
         FUSE(self, mount_point, **fuse_args)
 
     # Helpers
@@ -194,7 +206,7 @@ class FreezeFS(Operations, FileSystemEventHandler):
 
         item.freezetags.append(entry)
 
-        assert (not self._get_item(entry.path))
+        assert not self._get_item(entry.path)
 
         map = self.path_map
         parts = Path(entry.path).parts
@@ -229,18 +241,18 @@ class FreezeFS(Operations, FileSystemEventHandler):
             self._schedule_purge_ftag(path)
         except KeyboardInterrupt:
             raise
-        except:
-            print(f'cannot parse freezetag: {path}')
+        except Exception as e:
+            print(f'Cannot parse freezetag: {path}, error: {e}')
             return
         finally:
             self.freezetag_ref_lock.release()
 
-        self._log_verbose(f'adding freezetag: {path}')
+        self._log_verbose(f'Adding freezetag: {path}')
 
         root = Path('/') / freezetag.data.frozen.root
         item = self._get_item(root)
         if item:
-            print(f'cannot mount {path} to {root}: path already mounted by another freezetag')
+            print(f'Cannot mount {path} to {root}: path already mounted by another freezetag')
             self.inactive_freezetags.append([root, path])
             return
 
@@ -257,13 +269,13 @@ class FreezeFS(Operations, FileSystemEventHandler):
     def _add_file(self, src):
         try:
             st = src.stat()
-        except:
-            print(f'cannot stat file: {src}')
+        except Exception as e:
+            print(f'Cannot stat file: {src}, error: {e}')
             return
 
         cached = self.checksum_db.get(st.st_dev, st.st_ino, st.st_mtime)
         if cached:
-            self._log_verbose(f'adding cached file: {src}')
+            self._log_verbose(f'Adding cached file: {src}')
             checksum, metadata_info, metadata_len, mtime = cached
             entry = FrozenItemFileEntry(src, metadata_info, metadata_len)
             self._add_path_entry(checksum, entry)
@@ -274,13 +286,18 @@ class FreezeFS(Operations, FileSystemEventHandler):
             file.parse()
         except KeyboardInterrupt:
             raise
-        except:
-            print(f'cannot parse file: {src}')
+        except Exception as e:
+            print(f'Cannot parse file: {src}, error: {e}')
             return
 
-        self._log_verbose(f'adding new file: {src}')
+        self._log_verbose(f'Adding new file: {src}')
 
-        metadata = file.strip()
+        try:
+            metadata = file.strip()
+        except Exception as e:
+            print(f'Cannot strip metadata from file: {src}, error: {e}')
+            metadata = None
+
         metadata_info = list(metadata) if metadata else []
         metadata_len = sum(m[1] for m in metadata_info) if metadata else 0
         checksum = file.checksum()
@@ -308,7 +325,7 @@ class FreezeFS(Operations, FileSystemEventHandler):
             del self.abs_path_map[file_path]
 
     def _can_purge_ftag(self, path):
-        assert (self.freezetag_ref_lock.locked())
+        assert self.freezetag_ref_lock.locked()
 
         if path not in self.freezetag_refs:
             return True
@@ -327,16 +344,17 @@ class FreezeFS(Operations, FileSystemEventHandler):
             self.freezetag_ref_lock.release()
 
     def _schedule_purge_ftag(self, path):
-        assert (self.freezetag_ref_lock.locked())
+        assert self.freezetag_ref_lock.locked()
 
         t = Timer(FREEZETAG_KEEPALIVE_TIME, lambda: self._purge_ftag(path, force=False))
         t.start()
 
-        if not path in self.freezetag_refs:
+        if path not in self.freezetag_refs:
             self.freezetag_refs[path] = [t, 0]
         else:
             timer = self.freezetag_refs[path][0]
-            timer and timer.cancel()
+            if timer:
+                timer.cancel()
             self.freezetag_refs[path][0] = t
 
     # Filesystem methods
@@ -346,7 +364,7 @@ class FreezeFS(Operations, FileSystemEventHandler):
         path = Path(path)
 
         item = self._get_item(path)
-        if item == None:
+        if item is None:
             raise FuseOSError(ENOENT)
 
         if isinstance(item, FrozenItem):
@@ -418,8 +436,14 @@ class FreezeFS(Operations, FileSystemEventHandler):
                     metadata = f.metadata
                     break
 
-        file = FuseFile.from_info(file_entry.path, flags, metadata, file_entry.metadata_info, file_entry.metadata_len,
-                                  frozen_entry.metadata_len)
+        file = FuseFile.from_info(
+            file_entry.path,
+            flags,
+            metadata,
+            file_entry.metadata_info,
+            file_entry.metadata_len,
+            frozen_entry.metadata_len,
+        )
         self.fh_map[file.fh] = (file, freezetag_path)
         return file.fh
 
@@ -449,7 +473,7 @@ class FreezeFS(Operations, FileSystemEventHandler):
         if dst.is_dir():
             return
 
-        self._log_verbose(f'moved: {src} to {dst}')
+        self._log_verbose(f'Moved: {src} to {dst}')
 
         if src.suffix.lower() == '.ftag':
             self._purge_ftag(src, force=True)
@@ -496,7 +520,7 @@ class FreezeFS(Operations, FileSystemEventHandler):
         path = Path(event.src_path)
 
         if path.suffix.lower() != '.ftag':
-            self._log_verbose(f'deleting file {path}')
+            self._log_verbose(f'Deleting file {path}')
 
             item = self.abs_path_map.get(path)
             if not item:
@@ -509,7 +533,7 @@ class FreezeFS(Operations, FileSystemEventHandler):
                     break
             return
 
-        self._log_verbose(f'deleting freezetag {path}')
+        self._log_verbose(f'Deleting freezetag {path}')
 
         self._purge_ftag(path, force=True)
 

--- a/freezetag/freezefs.py
+++ b/freezetag/freezefs.py
@@ -140,7 +140,7 @@ class FreezeFS(Operations, FileSystemEventHandler):
 
         self.dir_stat = dir_stat_items
 
-    def mount(self, directory, mount_point, allow_other=False):
+    def mount(self, directory, mount_point):
         observer = Observer()
         observer.schedule(self, directory, recursive=True)
         observer.start()
@@ -161,9 +161,6 @@ class FreezeFS(Operations, FileSystemEventHandler):
             'fsname': 'freezefs',
             'volname': Path(mount_point).name,
         }
-
-        if allow_other:
-            fuse_args['allow_other'] = True
 
         # Only macOS supports FUSE volume names; remove it for other OSes
         if platform.system() != 'Darwin':


### PR DESCRIPTION
Adds support for passing through UID/GID as a mount argument. Defaults to the user executing the mount if not. Allows for mounting within a container as a non-root user without requiring su-exec, gosu, etc.