### PR TITLE
Adds mount support for fuse --allow-other

### DIFF
--- a/freezetag/__main__.py
+++ b/freezetag/__main__.py
@@ -103,18 +103,20 @@ def parse_args():
         ),
     )
     mount.add_argument(
+        '--allow-other',
+        action='store_true',
+        help='Allow other users to access the mounted filesystem.',
+    )
+    mount.add_argument(
         '--uid',
         type=int,
-        default=None,
-        help='Set the UID for the mounted filesystem. Default is the current user UID.',
+        help='Set the owner (user ID) of the mounted files.',
     )
     mount.add_argument(
         '--gid',
         type=int,
-        default=None,
-        help='Set the GID for the mounted filesystem. Default is the current user GID.',
+        help='Set the group (group ID) of the mounted files.',
     )
-
     show.add_argument(
         'path',
         nargs='?',

--- a/freezetag/commands.py
+++ b/freezetag/commands.py
@@ -421,9 +421,7 @@ def show(path, as_json, **kwargs):
             print(f'{f.checksum.hex()} {f.path}')
 
 
-def mount(directory, mount_point, verbose, db_path=None, uid=None, gid=None, **kwargs):
+def mount(directory, mount_point, verbose, db_path=None, uid=None, gid=None, allow_other=False, **kwargs):
     from .freezefs import FreezeFS
     fs = FreezeFS(verbose, db_path=db_path, uid=uid, gid=gid)
-    fs.mount(directory, mount_point)
-
-
+    fs.mount(directory, mount_point, allow_other=allow_other)

--- a/freezetag/freezefs.py
+++ b/freezetag/freezefs.py
@@ -140,7 +140,7 @@ class FreezeFS(Operations, FileSystemEventHandler):
 
         self.dir_stat = dir_stat_items
 
-    def mount(self, directory, mount_point):
+    def mount(self, directory, mount_point, allow_other=False):
         observer = Observer()
         observer.schedule(self, directory, recursive=True)
         observer.start()
@@ -165,6 +165,10 @@ class FreezeFS(Operations, FileSystemEventHandler):
         # Only macOS supports FUSE volume names; remove it for other OSes
         if platform.system() != 'Darwin':
             fuse_args.pop('volname', None)
+
+        # Add support for fuse allow_other
+        if allow_other:
+            fuse_args['allow_other'] = True
 
         self._log_verbose(f'Mounting FUSE with these args: {fuse_args}')
         FUSE(self, mount_point, **fuse_args)


### PR DESCRIPTION
This prevents a read/write issue to the fuse mount even with passing UID and GID flags in case qBittorrent executes a process as someone other than the PUID/PGID user.